### PR TITLE
Tried using "cores/2" for concurrency, it broke

### DIFF
--- a/wakaq/__init__.py
+++ b/wakaq/__init__.py
@@ -247,6 +247,6 @@ class WakaQ:
         if not concurrency:
             return 0
         try:
-            return safe_eval(str(concurrency), {"cores": multiprocessing.cpu_count()})
+            return int(safe_eval(str(concurrency), {"cores": multiprocessing.cpu_count()}))
         except Exception as e:
             raise Exception(f"Error parsing concurrency: {e}")


### PR DESCRIPTION
A simple change to allow simple expressions for number of cores that don't resolve to integers.

I've found this useful b/c I use a separate wakaq worker pool for very heavy tasks (many GB RAM per task), and I'd like to use a nice syntax like "cores/2" that wakaq supports for integer multiples of cores already.