### PR TITLE
allow direct control of concurrency

### DIFF
--- a/wakaq/__init__.py
+++ b/wakaq/__init__.py
@@ -247,6 +247,9 @@ class WakaQ:
         if not concurrency:
             return 0
         try:
-            return int(safe_eval(str(concurrency), {"cores": multiprocessing.cpu_count()}))
+            if isinstance(concurrency, int):
+                return concurrency
+            else:
+                return int(safe_eval(str(concurrency), {"cores": multiprocessing.cpu_count()}))
         except Exception as e:
             raise Exception(f"Error parsing concurrency: {e}")


### PR DESCRIPTION
Okay, one more idea about controlling concurrency slightly more directly.

Right now the behavior of `concurrency=2` and `concurrency="cores*2"` is identical. That seems unintuitive to me! I also would like direct control over exactly how many workers are running for debugging/testing purposes.

This change makes it so that `concurrency=${some_integer}` will cause the worker pool to have *exactly* that many workers, instead of `cpu_count()*some_integer`.