### PR TITLE
add synchronous mode for easier debugging

### DIFF
--- a/wakaq/__init__.py
+++ b/wakaq/__init__.py
@@ -67,6 +67,7 @@ class WakaQ:
         socket_connect_timeout=15,
         health_check_interval=30,
         wait_timeout=1,
+        synchronous_mode=False,
     ):
         self.queues = [Queue.create(x) for x in queues]
         if len(self.queues) == 0:
@@ -84,6 +85,7 @@ class WakaQ:
         self.soft_timeout = soft_timeout.total_seconds() if isinstance(soft_timeout, timedelta) else soft_timeout
         self.hard_timeout = hard_timeout.total_seconds() if isinstance(hard_timeout, timedelta) else hard_timeout
         self.wait_timeout = wait_timeout.total_seconds() if isinstance(wait_timeout, timedelta) else wait_timeout
+        self.synchronous_mode = synchronous_mode
 
         if self.soft_timeout and self.soft_timeout <= wait_timeout:
             raise Exception(

--- a/wakaq/task.py
+++ b/wakaq/task.py
@@ -2,6 +2,13 @@ from datetime import timedelta
 
 from .queue import Queue
 
+from functools import lru_cache
+import os
+
+@lru_cache(maxsize=1)
+def synchronous_mode():
+    return os.environ.get("WAKAQ_RUN_SYNC", None) is not None
+
 
 class Task:
     __slots__ = [
@@ -41,6 +48,10 @@ class Task:
 
         queue = kwargs.pop("queue", None) or self.queue
         eta = kwargs.pop("eta", None)
+
+        if synchronous_mode():
+            return self.fn(*args, **kwargs)
+
         if eta:
             self.wakaq._enqueue_with_eta(self.name, queue, args, kwargs, eta)
         else:

--- a/wakaq/task.py
+++ b/wakaq/task.py
@@ -2,13 +2,6 @@ from datetime import timedelta
 
 from .queue import Queue
 
-from functools import lru_cache
-import os
-
-@lru_cache(maxsize=1)
-def synchronous_mode():
-    return os.environ.get("WAKAQ_RUN_SYNC", None) is not None
-
 
 class Task:
     __slots__ = [
@@ -49,7 +42,7 @@ class Task:
         queue = kwargs.pop("queue", None) or self.queue
         eta = kwargs.pop("eta", None)
 
-        if synchronous_mode():
+        if self.wakaq.synchronous_mode:
             return self.fn(*args, **kwargs)
 
         if eta:


### PR DESCRIPTION
My teammates and I have been running into situations where debugging code inside wakaq workers that's getting called via `func.delay()` in our webserver process feels more painful than necessary. 

I'm hoping a small change like this or something similar could dramatically simplify the process by just letting us slap breakpoints in the code and be able to easily run the functions for debugging/development right in the same webserver process that's calling `func.delay()`.

- [ ] Changes to readme not included, pending some kind of approval.
- [ ] Some thought also likely needed for what to do with  `broadcast` and `_enqueued_with_eta` submissions in synchronous mode.

tested via setting up a `venv` and running the example from the readme in synchronous mode vs not:

```
python -m venv .venv
source .venv/bin/activate
pip install -r requirements.txt
# copy example from requirements to test.py
python test.py
> # fails at my_task.delay w/ no redis connection
# set synchronous_mode = True in WakaQ constructor call
python test.py
> 2
> 2
> hello_world
> hello_world  # returns with no delay, delay doesn't work in synchronous mode
```

I'm certainly sensitive to the motivation for not wanting more features in wakaq- it's simplicity is definitely part of why I like it. I hope this isn't in competition with that spirit. Let me know if it is.