### PR TITLE
Fix UnboundLocalError for async task context

### DIFF
--- a/wakaq/worker.py
+++ b/wakaq/worker.py
@@ -346,15 +346,19 @@ class Worker:
                                         log.error(traceback.format_exc())
 
                             for async_task in pending:
+                                context = self._async_task_context.get(async_task)
+                                if not context:
+                                    continue
                                 soft_timeout, _ = get_timeouts(self.wakaq, task=context["task"], queue=context["queue"])
-                                if soft_timeout:
-                                    runtime = time.time() - context["start_time"]
-                                    if runtime - 0.1 > soft_timeout and not async_task.cancelled():
-                                        current_task.set((context["task"], context["payload"]))
-                                        log.debug(
-                                            f"async task {context['task'].name} runtime {runtime} reached soft timeout, raising asyncio.CancelledError"
-                                        )
-                                        async_task.cancel()
+                                if not soft_timeout:
+                                    continue
+                                runtime = time.time() - context["start_time"]
+                                if runtime - 0.1 > soft_timeout and not async_task.cancelled():
+                                    current_task.set((context["task"], context["payload"]))
+                                    log.debug(
+                                        f"async task {context['task'].name} runtime {runtime} reached soft timeout, raising asyncio.CancelledError"
+                                    )
+                                    async_task.cancel()
 
                         current_task.set(None)
                         self._send_ping_to_parent()


### PR DESCRIPTION
Fixes `UnboundLocalError: local variable 'context' referenced before assignment`