### PR TITLE
Update custom_task_decorator portion in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ async def an_io_intensive_task():
 
 
 @wakaq.wrap_tasks_with
-def custom_task_decorator(fn, args, kwargs):
+async def custom_task_decorator(fn, args, kwargs):
     # do something before each task runs, for ex: `with app.app_context():`
     if inspect.iscoroutinefunction(fn):
-        await fn(*payload["args"], **payload["kwargs"])
+        await fn(*args, **kwargs)
     else:
-        fn(*payload["args"], **payload["kwargs"])
+        fn(*args, **kwargs)
     # do something after each task runs
 
 


### PR DESCRIPTION
Small update to the custom_task_decorator function in the README. 

- Changed the `*payload["args"]` and `**payload["kargs"]` references to `*args` and `**kwargs`.
- Corrected the function to be `async`
